### PR TITLE
Make NuGet.proj and build.bat work in project path containing spaces.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ ipch/
 
 # ReSharper is a .NET coding add-in
 _ReSharper*
+NuDoc.sln.DotSettings
 
 # NCrunch
 *.ncrunch*

--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,1 @@
-%WINDIR%\Microsoft.NET\Framework\v4.0.30319\msbuild %~dp0\src\NuDoc\NuGet.proj /verbosity:normal /nr:false
+%WINDIR%\Microsoft.NET\Framework\v4.0.30319\msbuild "%~dp0\src\NuDoc\NuGet.proj" /verbosity:normal /nr:false

--- a/src/NuDoc/NuGet.proj
+++ b/src/NuDoc/NuGet.proj
@@ -7,8 +7,8 @@
     <PropertyGroup>
         <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
         <BuildRoot>$(MSBuildThisFileDirectory)</BuildRoot>
-        <DropDirectory>$(BuildRoot)..\..\</DropDirectory>
-        <NuGetExe>$(BuildRoot)..\..\.nuget\NuGet.exe</NuGetExe>
+        <DropDirectory>"$(BuildRoot)..\.."</DropDirectory>
+        <NuGetExe>"$(BuildRoot)..\..\.nuget\NuGet.exe"</NuGetExe>
         <ReleaseNotes>$([System.IO.File]::ReadAllText('$(BuildRoot)..\..\ReleaseNotes.md'))</ReleaseNotes>
     </PropertyGroup>
 


### PR DESCRIPTION
`build.bat` does not work when NuDoc is located in a path containing spaces.  Change the following to fix this:
- Quote DropDirectory and remove trailing slash as advised here http://nuget.codeplex.com/workitem/901
- Quote NuGetExe.
- Quote NuGet.proj path in build.bat.

_Also, add ignore for R# dotsettings file._

All tests passed bar one relying on Win8 as I'm on Win2008.
