### PR TITLE
Fixed MemberIdMap for members that accept (or return) generic arrays

### DIFF
--- a/src/Demo/ClariusLabs.DemoProject/ClariusLabs.DemoProject.xml
+++ b/src/Demo/ClariusLabs.DemoProject/ClariusLabs.DemoProject.xml
@@ -110,6 +110,16 @@
             Generic method on non-generic type.
             </summary>
         </member>
+        <member name="M:ClariusLabs.Demo.Sample.DoWithArray1``1(``0[])">
+            <summary>
+            Generic method on non-generic type, accepting one-dimensional array.
+            </summary>
+        </member>
+        <member name="M:ClariusLabs.Demo.Sample.DoWithArray2``1(``0[0:,0:])">
+            <summary>
+            Generic method on non-generic type, accepting two-dimensional array.
+            </summary>
+        </member>
         <member name="P:ClariusLabs.Demo.Sample.Id">
             <summary>
             Gets or sets the id.

--- a/src/Demo/ClariusLabs.DemoProject/Sample.cs
+++ b/src/Demo/ClariusLabs.DemoProject/Sample.cs
@@ -80,6 +80,20 @@ namespace ClariusLabs.Demo
         }
 
         /// <summary>
+        /// Generic method on non-generic type, accepting one-dimensional array.
+        /// </summary>
+        public T DoWithArray1<T>(T[] array) {
+            return default(T);
+        }
+
+        /// <summary>
+        /// Generic method on non-generic type, accepting two-dimensional array.
+        /// </summary>
+        public T DoWithArray2<T>(T[,] array) {
+            return default(T);
+        }
+
+        /// <summary>
         /// A nested type
         /// </summary>
         public class NestedType

--- a/src/Demo/ClariusLabs.DemoSilverlight/ClariusLabs.DemoSilverlight.xml
+++ b/src/Demo/ClariusLabs.DemoSilverlight/ClariusLabs.DemoSilverlight.xml
@@ -110,6 +110,16 @@
             Generic method on non-generic type.
             </summary>
         </member>
+        <member name="M:ClariusLabs.Demo.Sample.DoWithArray1``1(``0[])">
+            <summary>
+            Generic method on non-generic type, accepting one-dimensional array.
+            </summary>
+        </member>
+        <member name="M:ClariusLabs.Demo.Sample.DoWithArray2``1(``0[0:,0:])">
+            <summary>
+            Generic method on non-generic type, accepting two-dimensional array.
+            </summary>
+        </member>
         <member name="P:ClariusLabs.Demo.Sample.Id">
             <summary>
             Gets or sets the id.

--- a/src/NuDoc.Tests/MemberIdMapFixture.cs
+++ b/src/NuDoc.Tests/MemberIdMapFixture.cs
@@ -80,7 +80,31 @@ namespace ClariusLabs.NuDoc
             var map = new MemberIdMap();
             map.Add(typeof(Sample));
 
-            var actual = map.FindId(typeof(Sample).GetMethods().Single(m => m.IsGenericMethod));
+            var actual = map.FindId(Reflect<Sample>.GetMethod(x => x.Do<object>(null)).GetGenericMethodDefinition());
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void when_mapping_generic_method_with_array_parameter_on_non_generic_type_then_matches_xml_format()
+        {
+            var expected = "M:ClariusLabs.Demo.Sample.DoWithArray1``1(``0[])";
+            var map = new MemberIdMap();
+            map.Add(typeof(Sample));
+
+            var actual = map.FindId(Reflect<Sample>.GetMethod(x => x.DoWithArray1<object>(null)).GetGenericMethodDefinition());
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void when_mapping_generic_method_with_two_dimensional_array_parameter_on_non_generic_type_then_matches_xml_format() 
+        {
+            var expected = "M:ClariusLabs.Demo.Sample.DoWithArray2``1(``0[0:,0:])";
+            var map = new MemberIdMap();
+            map.Add(typeof(Sample));
+
+            var actual = map.FindId(Reflect<Sample>.GetMethod(x => x.DoWithArray2<object>(null)).GetGenericMethodDefinition());
 
             Assert.Equal(expected, actual);
         }

--- a/src/NuDoc.Tests/ReaderFixture.cs
+++ b/src/NuDoc.Tests/ReaderFixture.cs
@@ -522,7 +522,31 @@ We can have paragraphs anywhere.
         {
             var map = new MemberIdMap();
             map.Add(assembly);
-            var typeId = map.FindId(typeof(Sample).GetMethods().Single(m => m.IsGenericMethod));
+            var typeId = map.FindId(Reflect<Sample>.GetMethod(x => x.Do<object>(null)).GetGenericMethodDefinition());
+            var member = DocReader.Read(assembly).Elements.OfType<Method>().Where(c => c.Id == typeId).FirstOrDefault();
+
+            Assert.NotNull(member);
+            Assert.NotNull(member.Info);
+        }
+
+        [Fact]
+        public void when_documenting_generic_method_with_array_parameter_then_sets_info()
+        {
+            var map = new MemberIdMap();
+            map.Add(assembly);
+            var typeId = map.FindId(Reflect<Sample>.GetMethod(x => x.DoWithArray1<object>(null)).GetGenericMethodDefinition());
+            var member = DocReader.Read(assembly).Elements.OfType<Method>().Where(c => c.Id == typeId).FirstOrDefault();
+
+            Assert.NotNull(member);
+            Assert.NotNull(member.Info);
+        }
+
+        [Fact]
+        public void when_documenting_generic_method_with_two_dimensional_array_parameter_then_sets_info()
+        {
+            var map = new MemberIdMap();
+            map.Add(assembly);
+            var typeId = map.FindId(Reflect<Sample>.GetMethod(x => x.DoWithArray2<object>(null)).GetGenericMethodDefinition());
             var member = DocReader.Read(assembly).Elements.OfType<Method>().Where(c => c.Id == typeId).FirstOrDefault();
 
             Assert.NotNull(member);

--- a/src/NuDoc/MemberIdMap.cs
+++ b/src/NuDoc/MemberIdMap.cs
@@ -219,9 +219,11 @@ namespace ClariusLabs.NuDoc
                 AppendType(sb, type.GetElementType());
                 sb.Append("[");
                 var rank = type.GetArrayRank();
-                if (rank > 1) {
+                if (rank > 1)
+                {
                     sb.Append("0:");
-                    for (var i = 2; i <= rank; i++) {
+                    for (var i = 2; i <= rank; i++)
+                    {
                         sb.Append(",0:");
                     }
                 }


### PR DESCRIPTION
Member signatures with generic arrays were not processed correctly — generated member id included `MyNamespace.T[]` instead of ```0`.
This pull request corrects it.

Note:
I can't open Metro and Phone projects, so this change requires someone to update those XML docs.
Otherwise the test that compares all projects will fail.
