### PR TITLE
Value content for See and SeeAlso tags

### DIFF
--- a/src/NuDoq/DocReader.cs
+++ b/src/NuDoq/DocReader.cs
@@ -66,8 +66,8 @@ namespace NuDoq
         {
             return Read(assembly, null);
         }
-     
-            /// <summary>
+
+        /// <summary>
         /// Uses the specified assembly to locate a documentation file alongside the assembly by 
         /// changing the extension to ".xml". If the file is found, it will be read and all 
         /// found members will contain extended reflection information in the <see cref="Member.Info"/> 
@@ -82,7 +82,7 @@ namespace NuDoq
         {
             var fileName = documentationFilename;
 
-            if(string.IsNullOrEmpty(fileName))
+            if (string.IsNullOrEmpty(fileName))
                 fileName = Path.ChangeExtension(assembly.Location, ".xml");
 
             if (!File.Exists(fileName))
@@ -239,10 +239,10 @@ namespace NuDoq
                                 element = new C(elementNode.Value);
                                 break;
                             case "see":
-                                element = new See(FindAttribute(elementNode, "cref"), FindAttribute(elementNode, "langword"), ReadContent(elementNode));
+                                element = new See(FindAttribute(elementNode, "cref"), FindAttribute(elementNode, "langword"), elementNode.Value, ReadContent(elementNode));
                                 break;
                             case "seealso":
-                                element = new SeeAlso(FindAttribute(elementNode, "cref"), ReadContent(elementNode));
+                                element = new SeeAlso(FindAttribute(elementNode, "cref"), elementNode.Value, ReadContent(elementNode));
                                 break;
                             case "list":
                                 element = new List(FindAttribute(elementNode, "type"), ReadContent(elementNode));
@@ -343,13 +343,13 @@ namespace NuDoq
                 indent = 0;
 
             return string.Join(joinWith, lines
-                .Select(line => 
+                .Select(line =>
                     {
-                        if(string.IsNullOrEmpty(line))
+                        if (string.IsNullOrEmpty(line))
                             return line;
                         else if (line.Length < indent)
                             return string.Empty;
-                        else 
+                        else
                             return line.Substring(indent);
                     })
                 .ToArray());

--- a/src/NuDoq/See.cs
+++ b/src/NuDoq/See.cs
@@ -33,12 +33,14 @@ namespace NuDoq
         /// </summary>
         /// <param name="cref">The member id of the referenced member, if any.</param>
         /// <param name="langword">The element langword, if any.</param>
+        /// <param name="content">The link's text label, if any.</param>
         /// <param name="elements">The child elements.</param>
-        public See(string cref, string langword, IEnumerable<Element> elements)
+        public See(string cref, string langword, string content, IEnumerable<Element> elements)
             : base(elements)
         {
             this.Cref = cref;
             this.Langword = langword;
+            this.Content = content;
         }
 
         /// <summary>
@@ -59,6 +61,11 @@ namespace NuDoq
         /// Gets the original langword attribute.
         /// </summary>
         public string Langword { get; private set; }
+
+        /// <summary>
+        /// Gets the reference's text.
+        /// </summary>
+        public string Content { get; private set; }
 
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.

--- a/src/NuDoq/SeeAlso.cs
+++ b/src/NuDoq/SeeAlso.cs
@@ -32,11 +32,13 @@ namespace NuDoq
         /// Initializes a new instance of the <see cref="SeeAlso"/> class.
         /// </summary>
         /// <param name="cref">The member id of the referenced member.</param>
+        /// <param name="content">The link's text label, if any.</param>
         /// <param name="elements">The child elements.</param>
-        public SeeAlso(string cref, IEnumerable<Element> elements)
+        public SeeAlso(string cref, string content, IEnumerable<Element> elements)
             : base(elements)
         {
             this.Cref = cref;
+            this.Content = content;
         }
 
         /// <summary>
@@ -52,6 +54,11 @@ namespace NuDoq
         /// Gets the member id of the referenced member.
         /// </summary>
         public string Cref { get; private set; }
+
+        /// <summary>
+        /// Gets the reference's text.
+        /// </summary>
+        public string Content { get; private set; }
 
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.


### PR DESCRIPTION
Pull request for issue #11 (Value content for See and SeeAlso tags). The following changes expand the See and SeeAlso classes to offer a "Content" property containing the inner text of the reference label.
