### PR TITLE
Add support for extended documentation attributes

### DIFF
--- a/src/NuDoq.Tests/.editorconfig
+++ b/src/NuDoq.Tests/.editorconfig
@@ -4,3 +4,12 @@
 
 # CS1591: Missing XML comment for publicly visible type or member
 dotnet_diagnostic.CS1591.severity = none
+
+# Default severity for analyzer diagnostics with category 'Style'
+dotnet_analyzer_diagnostic.category-Style.severity = none
+
+# CS1712: Type parameter has no matching typeparam tag in the XML comment (but other type parameters do)
+dotnet_diagnostic.CS1712.severity = none
+
+# CS1710: XML comment has a duplicate typeparam tag
+dotnet_diagnostic.CS1710.severity = none

--- a/src/NuDoq.Tests/MemberIdMapFixture.cs
+++ b/src/NuDoq.Tests/MemberIdMapFixture.cs
@@ -37,8 +37,8 @@ namespace NuDoq
 
             var id = map.FindId(typeof(Sample));
 
-            Assert.True(map.Ids.Contains(id));
-            Assert.True(map.Members.Contains(typeof(Sample)));
+            Assert.Contains(id, map.Ids);
+            Assert.Contains(typeof(Sample), map.Members);
         }
 
         [Fact]

--- a/src/NuDoq.Tests/NuDoq.Tests.csproj
+++ b/src/NuDoq.Tests/NuDoq.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <TargetFramework Condition="'$(BuildingInsideVisualStudio)' == 'true'">net472</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuDoq.Tests/TestOutputTextWriter.cs
+++ b/src/NuDoq.Tests/TestOutputTextWriter.cs
@@ -1,0 +1,40 @@
+﻿using System.IO;
+using System.Text;
+using Xunit.Abstractions;
+
+namespace NuDoq
+{
+    class TestOutputTextWriter : TextWriter
+    {
+        StringBuilder buffer = new StringBuilder();
+        readonly ITestOutputHelper output;
+
+        public TestOutputTextWriter(ITestOutputHelper output) => this.output = output;
+
+        public override Encoding Encoding => Encoding.Unicode;
+
+        public override void Write(char value) => buffer.Append(value);
+
+        public override void WriteLine(string value)
+        {
+            buffer.Append(value);
+            Flush();
+        }
+
+        public override void Flush()
+        {
+            var sb = buffer;
+            if (sb.Length > 0)
+            {
+                buffer = new StringBuilder();
+                output.WriteLine(sb.ToString());
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Flush();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/NuDoq.Tests/ToTextFixture.cs
+++ b/src/NuDoq.Tests/ToTextFixture.cs
@@ -42,7 +42,7 @@ namespace NuDoq
             var xmlFile = Path.ChangeExtension(assembly.Location, ".xml");
             var members = DocReader.Read(assembly);
 
-            Assert.True(members.ToString().Contains(assembly.Location));
+            Assert.Contains(assembly.Location, members.ToString());
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace NuDoq
             var xmlFile = Path.ChangeExtension(assembly.Location, ".xml");
             var members = DocReader.Read(xmlFile);
 
-            Assert.True(members.ToString().Contains(xmlFile));
+            Assert.Contains(xmlFile, members.ToString());
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace NuDoq
             var xmlFile = Path.ChangeExtension(assembly.Location, ".xml");
             var member = DocReader.Read(xmlFile).Elements.OfType<Member>().First();
 
-            Assert.True(member.ToString().Contains(member.Id));
+            Assert.Contains(member.Id, member.ToString());
         }
 
         [Fact]

--- a/src/NuDoq.Tests/XmlNormalizerFixture.cs
+++ b/src/NuDoq.Tests/XmlNormalizerFixture.cs
@@ -309,9 +309,9 @@ namespace NuDoq
             var d2 = XDocument.Parse(doc2);
 
             if (expectedEquals == true)
-                Assert.True(XmlNormalizer.NormalizedEquals(d1, d2, schemaSet));
+                Assert.True(XmlNormalizer.NormalizedEquals(d1, d2, schemaSet), description);
             else
-                Assert.False(XmlNormalizer.NormalizedEquals(d1, d2, schemaSet));
+                Assert.False(XmlNormalizer.NormalizedEquals(d1, d2, schemaSet), description);
         }
     }
 }

--- a/src/NuDoq.Tests/XmlVisitorFixture.cs
+++ b/src/NuDoq.Tests/XmlVisitorFixture.cs
@@ -1,15 +1,19 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
 using Demo;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NuDoq
 {
     public class XmlVisitorFixture
     {
+        readonly ITestOutputHelper output;
+
+        public XmlVisitorFixture(ITestOutputHelper output) => this.output = output;
+
         [Fact]
         public void when_visiting_xml_then_adds_source_assembly()
         {
@@ -54,9 +58,9 @@ namespace NuDoq
             //Assert.True(originalXml.NormalizedEquals(visitor.Xml));
         }
 
-        static void WriteXml(XDocument xml)
+        void WriteXml(XDocument xml)
         {
-            using (var writer = XmlWriter.Create(Console.Out, new XmlWriterSettings { OmitXmlDeclaration = true, Indent = true }))
+            using (var writer = XmlWriter.Create(new TestOutputTextWriter(output), new XmlWriterSettings { OmitXmlDeclaration = true, Indent = true }))
             {
                 xml.WriteTo(writer);
             }

--- a/src/NuDoq/C.cs
+++ b/src/NuDoq/C.cs
@@ -1,4 +1,6 @@
-﻿namespace NuDoq
+﻿using System.Collections.Generic;
+
+namespace NuDoq
 {
     /// <summary>
     /// Represents the <c>c</c> documentation tag.
@@ -12,7 +14,9 @@
         /// Initializes a new instance of the <see cref="C"/> class 
         /// with the given content.
         /// </summary>
-        public C(string content) => Content = content;
+        public C(string content, IDictionary<string, string> attributes)
+            : base(attributes)
+            => Content = content;
 
         /// <summary>
         /// Accepts the specified visitor.

--- a/src/NuDoq/Code.cs
+++ b/src/NuDoq/Code.cs
@@ -1,4 +1,6 @@
-﻿namespace NuDoq
+﻿using System.Collections.Generic;
+
+namespace NuDoq
 {
     /// <summary>
     /// Represents the <c>code</c> documentation tag.
@@ -12,7 +14,9 @@
         /// Initializes a new instance of the <see cref="Code"/> class 
         /// with the given content.
         /// </summary>
-        public Code(string content) => Content = content;
+        public Code(string content, IDictionary<string, string> attributes)
+            : base(attributes)
+            => Content = content;
 
         /// <summary>
         /// Accepts the specified visitor.

--- a/src/NuDoq/Container.cs
+++ b/src/NuDoq/Container.cs
@@ -14,7 +14,10 @@ namespace NuDoq
         /// Initializes a new instance of the <see cref="Container"/> class.
         /// </summary>
         /// <param name="elements">The contained elements within this instance.</param>
-        public Container(IEnumerable<Element> elements) => Elements = elements.Cached();
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Container(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(attributes)
+            => Elements = elements.Cached();
 
         /// <summary>
         /// Gets the elements contained in this instance.

--- a/src/NuDoq/Description.cs
+++ b/src/NuDoq/Description.cs
@@ -14,8 +14,9 @@ namespace NuDoq
         /// Initializes a new instance of the <see cref="Description"/> class.
         /// </summary>
         /// <param name="elements">The elements that make up the description.</param>
-        public Description(IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Description(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
         }
 

--- a/src/NuDoq/DocumentMembers.cs
+++ b/src/NuDoq/DocumentMembers.cs
@@ -18,7 +18,7 @@ namespace NuDoq
         /// <param name="members">The lazily-read members of the set.</param>
         public DocumentMembers(XDocument xml, IEnumerable<Member> members)
             // In .NET 3.5 there's no covariance on IEnumerable.
-            : base(members.OfType<Element>())
+            : base(members.OfType<Element>(), new Dictionary<string, string>())
             => Xml = xml;
 
         /// <summary>

--- a/src/NuDoq/Element.cs
+++ b/src/NuDoq/Element.cs
@@ -17,6 +17,22 @@ namespace NuDoq
         IXmlLineInfo? lineInfo;
 
         /// <summary>
+        /// Initializes the element with the given attributes.
+        /// </summary>
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        protected Element(IDictionary<string, string> attributes) => Attributes = attributes;
+
+        /// <summary>
+        /// Gets all the attributes of the element.
+        /// </summary>
+        public IDictionary<string, string> Attributes { get; }
+
+        /// <summary>
+        /// Enumerates this instance and all its descendents recursively.
+        /// </summary>
+        public IEnumerable<Element> Traverse() => Accept(new TraverseVisitor()).Elements;
+
+        /// <summary>
         /// Accepts the specified visitor.
         /// </summary>
         public abstract TVisitor Accept<TVisitor>(TVisitor visitor) where TVisitor : Visitor;
@@ -42,11 +58,6 @@ namespace NuDoq
 
             return "";
         }
-
-        /// <summary>
-        /// Enumerates this instance and all its descendents recursively.
-        /// </summary>
-        public IEnumerable<Element> Traverse() => Accept(new TraverseVisitor()).Elements;
 
         internal void SetLineInfo(IXmlLineInfo lineInfo) => this.lineInfo = lineInfo;
 

--- a/src/NuDoq/Event.cs
+++ b/src/NuDoq/Event.cs
@@ -16,8 +16,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="memberId">The member id.</param>
         /// <param name="elements">The contained documentation elements.</param>
-        public Event(string memberId, IEnumerable<Element> elements)
-            : base(memberId, elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Event(string memberId, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(memberId, elements, attributes)
         {
         }
 

--- a/src/NuDoq/Example.cs
+++ b/src/NuDoq/Example.cs
@@ -14,8 +14,9 @@ namespace NuDoq
         /// Initializes a new instance of the <see cref="Example"/> class.
         /// </summary>
         /// <param name="elements">The contained elements within this instance.</param>
-        public Example(IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Example(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
         }
 

--- a/src/NuDoq/Exception.cs
+++ b/src/NuDoq/Exception.cs
@@ -15,8 +15,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="cref">The member id of the exception type.</param>
         /// <param name="elements">The elements that explain when this exception is thrown.</param>
-        public Exception(string cref, IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Exception(string cref, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
             Cref = cref;
         }

--- a/src/NuDoq/Field.cs
+++ b/src/NuDoq/Field.cs
@@ -16,8 +16,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="memberId">The member id.</param>
         /// <param name="elements">The contained documentation elements.</param>
-        public Field(string memberId, IEnumerable<Element> elements)
-            : base(memberId, elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Field(string memberId, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(memberId, elements, attributes)
         {
         }
 

--- a/src/NuDoq/Item.cs
+++ b/src/NuDoq/Item.cs
@@ -15,8 +15,9 @@ namespace NuDoq
         /// Initializes a new instance of the <see cref="Item"/> class.
         /// </summary>
         /// <param name="elements">The contained elements within this instance.</param>
-        public Item(IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Item(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
         }
 

--- a/src/NuDoq/List.cs
+++ b/src/NuDoq/List.cs
@@ -17,8 +17,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="type">The type of list, which can be "bullet", "number" or "table".</param>
         /// <param name="elements">The elements.</param>
-        public List(string type, IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public List(string type, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
             Type = ListType.Unknown;
             if (!string.IsNullOrEmpty(type))

--- a/src/NuDoq/ListHeader.cs
+++ b/src/NuDoq/ListHeader.cs
@@ -15,8 +15,9 @@ namespace NuDoq
         /// Initializes a new instance of the <see cref="ListHeader"/> class.
         /// </summary>
         /// <param name="elements">The contained elements within this instance.</param>
-        public ListHeader(IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public ListHeader(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
         }
 

--- a/src/NuDoq/Member.cs
+++ b/src/NuDoq/Member.cs
@@ -17,8 +17,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="memberId">The member id as specified in the documentation XML.</param>
         /// <param name="elements">The contained documentation elements.</param>
-        public Member(string memberId, IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Member(string memberId, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
             => Id = memberId;
 
         /// <summary>

--- a/src/NuDoq/Method.cs
+++ b/src/NuDoq/Method.cs
@@ -16,8 +16,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="memberId">The member id as specified in the documentation XML.</param>
         /// <param name="elements">The contained documentation elements.</param>
-        public Method(string memberId, IEnumerable<Element> elements)
-            : base(memberId, elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Method(string memberId, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(memberId, elements, attributes)
         {
         }
 

--- a/src/NuDoq/Para.cs
+++ b/src/NuDoq/Para.cs
@@ -14,8 +14,9 @@ namespace NuDoq
         /// Initializes a new instance of the <see cref="Para"/> class.
         /// </summary>
         /// <param name="elements">The contained elements within this instance.</param>
-        public Para(IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Para(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
         }
 

--- a/src/NuDoq/Param.cs
+++ b/src/NuDoq/Param.cs
@@ -15,8 +15,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="name">The name of the parameter.</param>
         /// <param name="elements">The elements that make up the parameter documentation.</param>
-        public Param(string name, IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Param(string name, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
             => Name = name;
 
         /// <summary>

--- a/src/NuDoq/ParamRef.cs
+++ b/src/NuDoq/ParamRef.cs
@@ -1,4 +1,6 @@
-﻿namespace NuDoq
+﻿using System.Collections.Generic;
+
+namespace NuDoq
 {
     /// <summary>
     /// Represents the <c>paramref</c> documentation tag.
@@ -12,7 +14,10 @@
         /// Initializes a new instance of the <see cref="ParamRef"/> class.
         /// </summary>
         /// <param name="name">The name of the referenced parameter.</param>
-        public ParamRef(string name) => Name = name;
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public ParamRef(string name, IDictionary<string, string> attributes)
+            : base(attributes)
+            => Name = name;
 
         /// <summary>
         /// Accepts the specified visitor.

--- a/src/NuDoq/Property.cs
+++ b/src/NuDoq/Property.cs
@@ -16,8 +16,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="memberId">The member id as specified in the documentation XML.</param>
         /// <param name="elements">The contained documentation elements.</param>
-        public Property(string memberId, IEnumerable<Element> elements)
-            : base(memberId, elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Property(string memberId, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(memberId, elements, attributes)
         {
         }
 

--- a/src/NuDoq/Remarks.cs
+++ b/src/NuDoq/Remarks.cs
@@ -14,8 +14,9 @@ namespace NuDoq
         /// Initializes a new instance of the <see cref="Remarks"/> class.
         /// </summary>
         /// <param name="elements">The contained elements within this instance.</param>
-        public Remarks(IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Remarks(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
         }
 

--- a/src/NuDoq/Returns.cs
+++ b/src/NuDoq/Returns.cs
@@ -14,8 +14,9 @@ namespace NuDoq
         /// Initializes a new instance of the <see cref="Returns"/> class.
         /// </summary>
         /// <param name="elements">The contained elements within this instance.</param>
-        public Returns(IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Returns(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
         }
 

--- a/src/NuDoq/See.cs
+++ b/src/NuDoq/See.cs
@@ -17,8 +17,9 @@ namespace NuDoq
         /// <param name="langword">The element langword, if any.</param>
         /// <param name="content">The link's text label, if any.</param>
         /// <param name="elements">The child elements.</param>
-        public See(string cref, string langword, string content, IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public See(string cref, string langword, string content, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
             Cref = cref;
             Langword = langword;

--- a/src/NuDoq/SeeAlso.cs
+++ b/src/NuDoq/SeeAlso.cs
@@ -16,8 +16,9 @@ namespace NuDoq
         /// <param name="cref">The member id of the referenced member.</param>
         /// <param name="content">The link's text label, if any.</param>
         /// <param name="elements">The child elements.</param>
-        public SeeAlso(string cref, string content, IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public SeeAlso(string cref, string content, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
             Cref = cref;
             Content = content;

--- a/src/NuDoq/Semantic/Class.cs
+++ b/src/NuDoq/Semantic/Class.cs
@@ -14,8 +14,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="memberId">The member id as specified in the documentation XML.</param>
         /// <param name="elements">The contained documentation elements.</param>
-        public Class(string memberId, IEnumerable<Element> elements)
-            : base(memberId, elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Class(string memberId, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(memberId, elements, attributes)
         {
         }
 

--- a/src/NuDoq/Semantic/Enum.cs
+++ b/src/NuDoq/Semantic/Enum.cs
@@ -14,8 +14,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="memberId">The member id as specified in the documentation XML.</param>
         /// <param name="elements">The contained documentation elements.</param>
-        public Enum(string memberId, IEnumerable<Element> elements)
-            : base(memberId, elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Enum(string memberId, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(memberId, elements, attributes)
         {
         }
 

--- a/src/NuDoq/Semantic/ExtensionMethod.cs
+++ b/src/NuDoq/Semantic/ExtensionMethod.cs
@@ -15,8 +15,9 @@ namespace NuDoq
         /// <param name="memberId">The extension method member id.</param>
         /// <param name="extendedTypeId">The extended type id (the <c>this</c> parameter).</param>
         /// <param name="elements">The contained documentation elements.</param>
-        public ExtensionMethod(string memberId, string extendedTypeId, IEnumerable<Element> elements)
-            : base(memberId, elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public ExtensionMethod(string memberId, string extendedTypeId, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(memberId, elements, attributes)
             => ExtendedTypeId = extendedTypeId;
 
         /// <summary>

--- a/src/NuDoq/Semantic/Interface.cs
+++ b/src/NuDoq/Semantic/Interface.cs
@@ -14,8 +14,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="memberId">The member id as specified in the documentation XML.</param>
         /// <param name="elements">The contained documentation elements.</param>
-        public Interface(string memberId, IEnumerable<Element> elements)
-            : base(memberId, elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Interface(string memberId, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(memberId, elements, attributes)
         {
         }
 

--- a/src/NuDoq/Semantic/Struct.cs
+++ b/src/NuDoq/Semantic/Struct.cs
@@ -14,8 +14,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="memberId">The member id as specified in the documentation XML.</param>
         /// <param name="elements">The contained documentation elements.</param>
-        public Struct(string memberId, IEnumerable<Element> elements)
-            : base(memberId, elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Struct(string memberId, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(memberId, elements, attributes)
         {
         }
 

--- a/src/NuDoq/Summary.cs
+++ b/src/NuDoq/Summary.cs
@@ -14,8 +14,9 @@ namespace NuDoq
         /// Initializes a new instance of the <see cref="Summary"/> class.
         /// </summary>
         /// <param name="elements">The contained elements within this instance.</param>
-        public Summary(IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Summary(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
         }
 

--- a/src/NuDoq/Term.cs
+++ b/src/NuDoq/Term.cs
@@ -14,8 +14,9 @@ namespace NuDoq
         /// Initializes a new instance of the <see cref="Term"/> class.
         /// </summary>
         /// <param name="elements">The contained elements within this instance.</param>
-        public Term(IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Term(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
         }
 

--- a/src/NuDoq/Text.cs
+++ b/src/NuDoq/Text.cs
@@ -1,4 +1,6 @@
-﻿namespace NuDoq
+﻿using System.Collections.Generic;
+
+namespace NuDoq
 {
     /// <summary>
     /// Represents basic literal text in the documentation.
@@ -9,7 +11,9 @@
         /// Initializes a new instance of the <see cref="Text"/> class.
         /// </summary>
         /// <param name="content">The literal text content.</param>
-        public Text(string content) => Content = content;
+        public Text(string content)
+            : base(new Dictionary<string, string>())
+            => Content = content;
 
         /// <summary>
         /// Accepts the specified visitor.

--- a/src/NuDoq/TypeDeclaration.cs
+++ b/src/NuDoq/TypeDeclaration.cs
@@ -16,8 +16,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="memberId">The member id as specified in the documentation XML.</param>
         /// <param name="elements">The contained documentation elements.</param>
-        public TypeDeclaration(string memberId, IEnumerable<Element> elements)
-            : base(memberId, elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public TypeDeclaration(string memberId, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(memberId, elements, attributes)
         {
         }
 

--- a/src/NuDoq/TypeParam.cs
+++ b/src/NuDoq/TypeParam.cs
@@ -15,8 +15,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="name">The name of the type parameter.</param>
         /// <param name="elements">The elements that make up the documentation.</param>
-        public TypeParam(string name, IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public TypeParam(string name, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
             => Name = name;
 
         /// <summary>

--- a/src/NuDoq/TypeParamRef.cs
+++ b/src/NuDoq/TypeParamRef.cs
@@ -1,4 +1,6 @@
-﻿namespace NuDoq
+﻿using System.Collections.Generic;
+
+namespace NuDoq
 {
     /// <summary>
     /// Represents the <c>typeparamref</c> documentation tag.
@@ -12,7 +14,10 @@
         /// Initializes a new instance of the <see cref="TypeParamRef"/> class.
         /// </summary>
         /// <param name="name">The name of the referenced type parameter.</param>
-        public TypeParamRef(string name) => Name = name;
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public TypeParamRef(string name, IDictionary<string, string> attributes)
+            : base(attributes)
+            => Name = name;
 
         /// <summary>
         /// Accepts the specified visitor.

--- a/src/NuDoq/UnknownElement.cs
+++ b/src/NuDoq/UnknownElement.cs
@@ -13,8 +13,9 @@ namespace NuDoq
         /// </summary>
         /// <param name="xml">The <see cref="XElement"/> containing the entire element markup.</param>
         /// <param name="content">The child content.</param>
-        public UnknownElement(XElement xml, IEnumerable<Element> content)
-            : base(content)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public UnknownElement(XElement xml, IEnumerable<Element> content, IDictionary<string, string> attributes)
+            : base(content, attributes)
             => Xml = xml;
 
         /// <summary>

--- a/src/NuDoq/UnknownMember.cs
+++ b/src/NuDoq/UnknownMember.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace NuDoq
 {
@@ -15,8 +16,9 @@ namespace NuDoq
         /// Initializes a new instance of the <see cref="UnknownMember"/> class.
         /// </summary>
         /// <param name="memberId">The member id.</param>
-        public UnknownMember(string memberId)
-            : base(memberId, Enumerable.Empty<Element>())
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public UnknownMember(string memberId, IDictionary<string, string> attributes)
+            : base(memberId, Enumerable.Empty<Element>(), attributes)
         {
         }
 

--- a/src/NuDoq/Value.cs
+++ b/src/NuDoq/Value.cs
@@ -14,8 +14,9 @@ namespace NuDoq
         /// Initializes a new instance of the <see cref="Value"/> class.
         /// </summary>
         /// <param name="elements">The contained elements within this instance.</param>
-        public Value(IEnumerable<Element> elements)
-            : base(elements)
+        /// <param name="attributes">The attributes of the element, if any.</param>
+        public Value(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
         {
         }
 


### PR DESCRIPTION
We already supported parsing `UnknownElement`, but we were losing information about custom attributes. We now preserve them too, which is important for extensibility scenarios like sandcastle or custom doc comments.

Fixes #1