### PR TITLE
Enable newline preservation

### DIFF
--- a/src/NuDoq.Tests/ReaderFixture.cs
+++ b/src/NuDoq.Tests/ReaderFixture.cs
@@ -649,6 +649,22 @@ We can have paragraphs anywhere.
             Assert.Equal("out", method.Elements.OfType<Param>().First().Elements.OfType<Text>().First().Content);
         }
 
+        [Fact]
+        public void when_reading_with_keep_lines_then_preserves_original_text()
+        {
+            var member = DocReader.Read(Assembly.GetExecutingAssembly(), new ReaderOptions { KeepNewLinesInText = true });
+            var method = member.Elements.OfType<Property>()
+                .FirstOrDefault(m => m.Info?.DeclaringType == typeof(CustomXml) && m.Info?.Name == nameof(CustomXml.NewLines));
+
+            Assert.NotNull(method);
+            Assert.Equal(@"With
+
+new
+
+
+lines", method.Elements.OfType<Summary>().First().Elements.OfType<Text>().First().Content);
+        }
+
         class CountingVisitor : Visitor
         {
             readonly string platform;
@@ -711,6 +727,16 @@ We can have paragraphs anywhere.
             {
                 p1 = default;
             }
+
+            /// <summary>
+            /// With
+            /// 
+            /// new
+            /// 
+            /// 
+            /// lines
+            /// </summary>
+            public string NewLines { get; set; }
         }
     }
 }

--- a/src/NuDoq.Tests/SampleTypes/Foo.cs
+++ b/src/NuDoq.Tests/SampleTypes/Foo.cs
@@ -6,7 +6,7 @@
         /// Some method
         /// </summary>
         /// <param name="x">The x param</param>
-        public void SomeMethod<T>(ref string x)
+        public void SomeMethod<TMethod>(ref string x)
         {
         }
     }

--- a/src/NuDoq/Element.cs
+++ b/src/NuDoq/Element.cs
@@ -59,7 +59,32 @@ namespace NuDoq
             return "";
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the class can return line information.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if <see cref="Element.LineNumber"/> and <see cref="Element.LinePosition"/> 
+        /// can be provided; otherwise, <c>false</c>.
+        /// </returns>
+        protected bool HasLineInfo() => lineInfo != null && lineInfo.HasLineInfo();
+
+        /// <summary>
+        /// Gets the current line number.
+        /// </summary>
+        protected int LineNumber => lineInfo == null ? 0 : lineInfo.LineNumber;
+
+        /// <summary>
+        /// Gets the current line position.
+        /// </summary>
+        protected int LinePosition => lineInfo == null ? 0 : lineInfo.LinePosition;
+
         internal void SetLineInfo(IXmlLineInfo lineInfo) => this.lineInfo = lineInfo;
+
+        bool IXmlLineInfo.HasLineInfo() => HasLineInfo();
+
+        int IXmlLineInfo.LineNumber => LineNumber;
+
+        int IXmlLineInfo.LinePosition => LinePosition;
 
         class TraverseVisitor : Visitor
         {
@@ -73,11 +98,5 @@ namespace NuDoq
 
             public List<Element> Elements { get; set; }
         }
-
-        bool IXmlLineInfo.HasLineInfo() => lineInfo != null && lineInfo.HasLineInfo();
-
-        int IXmlLineInfo.LineNumber => lineInfo == null ? 0 : lineInfo.LineNumber;
-
-        int IXmlLineInfo.LinePosition => lineInfo == null ? 0 : lineInfo.LinePosition;
     }
 }


### PR DESCRIPTION
When generating markdown or other text-based representation, it's useful to be able to read doc coments while still preserving the newlines.

Fixes #20