### PR TITLE
🔗 Adds href to see and seealso

### DIFF
--- a/src/NuDoq.Tests/DelegateVisitorFixture.cs
+++ b/src/NuDoq.Tests/DelegateVisitorFixture.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Concurrent;
 using System.Linq.Expressions;
+using System.Net.Http;
 using System.Reflection;
+using System.Threading.Tasks;
 using Demo;
 using Xunit;
 
@@ -36,6 +38,53 @@ namespace NuDoq
 
                 Assert.True(calls.GetOrAdd(prop, 0) > 0, string.Format("Delegate on {0} was not called.", prop.Name));
             }
+
+            when_visiting_root_then_can_validate_all_crefs();
+        }
+
+        /// <summary>
+        /// Summary seealso <seealso href="https://www.google.com"/> or <see href="https://foo.bar.baz"/>.
+        /// </summary>
+        /// <remarks>
+        /// Remarks seealso <seealso href="https://www.google.com"/> or <see href="https://foo.bar.baz"/>.
+        /// </remarks>
+        [Fact]
+        public void when_visiting_root_then_can_validate_all_crefs()
+        {
+            var members = DocReader.Read(Assembly.GetExecutingAssembly());
+            var http = new HttpClient();
+
+            var validUrls = 0;
+            var invalidUrls = 0;
+
+            void ValidateUrl(string? href)
+            {
+                if (string.IsNullOrEmpty(href))
+                    return;
+
+                try
+                {
+                    if (http.GetAsync(href).Result.IsSuccessStatusCode)
+                        validUrls++;
+                    else
+                        invalidUrls++;
+                }
+                catch
+                {
+                    invalidUrls++;
+                }
+            }
+
+            var visitor = new DelegateVisitor(new VisitorDelegates
+            {
+                VisitSee = see => ValidateUrl(see.Href),
+                VisitSeeAlso = seealso => ValidateUrl(seealso.Href),
+            });
+
+            members.Accept(visitor);
+
+            Assert.Equal(2, validUrls);
+            Assert.Equal(2, invalidUrls);
         }
 
         void Called(PropertyInfo property)

--- a/src/NuDoq.Tests/NuDoq.Tests.csproj
+++ b/src/NuDoq.Tests/NuDoq.Tests.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.8.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/NuDoq/DocumentMembers.cs
+++ b/src/NuDoq/DocumentMembers.cs
@@ -17,8 +17,7 @@ namespace NuDoq
         /// <param name="xml">The source XML document that was used to read the members.</param>
         /// <param name="members">The lazily-read members of the set.</param>
         public DocumentMembers(XDocument xml, IEnumerable<Member> members)
-            // In .NET 3.5 there's no covariance on IEnumerable.
-            : base(members.OfType<Element>(), new Dictionary<string, string>())
+            : base(members, new Dictionary<string, string>())
             => Xml = xml;
 
         /// <summary>

--- a/src/NuDoq/See.cs
+++ b/src/NuDoq/See.cs
@@ -51,6 +51,11 @@ namespace NuDoq
         public string Content { get; }
 
         /// <summary>
+        /// Gets the hyperlink, if present.
+        /// </summary>
+        public string? Href => Attributes.TryGetValue("href", out var href) ? href : null;
+
+        /// <summary>
         /// Returns a <see cref="string" /> that represents this instance.
         /// </summary>
         public override string ToString() => "<see>" + base.ToString();

--- a/src/NuDoq/SeeAlso.cs
+++ b/src/NuDoq/SeeAlso.cs
@@ -44,6 +44,11 @@ namespace NuDoq
         public string Content { get; }
 
         /// <summary>
+        /// Gets the hyperlink, if present.
+        /// </summary>
+        public string? Href => Attributes.TryGetValue("href", out var href) ? href : null;
+
+        /// <summary>
         /// Returns a <see cref="string" /> that represents this instance.
         /// </summary>
         public override string ToString() => "<seealso>" + base.ToString();

--- a/src/NuDoq/XmlVisitor.cs
+++ b/src/NuDoq/XmlVisitor.cs
@@ -5,7 +5,8 @@ using System.Xml.Linq;
 namespace NuDoq
 {
     /// <summary>
-    /// 
+    /// A visitor that creates an XML documentation file from an in-memory 
+    /// model of all members.
     /// </summary>
     public class XmlVisitor : Visitor
     {


### PR DESCRIPTION
Visual Studio 2019 (16.8+) supports href natively in the IDE,
rendering the hyperlinks in tooltips that allow easy navigation.

This adds the property as a first-class member so it's easier to
discover, and a test using the delegate visitor shows how it
can be used to validate links in your docs.

Fixes #35