### PR TITLE
@ Add support for custom attributes in XmlVisitor

### DIFF
--- a/src/NuDoq.Tests/CustomXml.cs
+++ b/src/NuDoq.Tests/CustomXml.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuDoq
+{
+    /// <summary>
+    /// This element contains 
+    /// <custom id="value">
+    /// element with <nested class="help">nested</nested> elements.
+    /// </custom>
+    /// </summary>
+    /// <remarks>
+    /// <code source="foo.cs" region="example" />
+    /// </remarks>
+    public class CustomXml
+    {
+        ///     <summary>
+        ///   Begin
+        ///  End
+        ///     </summary>
+        public void WeirdIndenting() { }
+
+        /// <preliminary />
+        public void Preliminary() { }
+
+        /// <summary>example method</summary>
+        /// <param name="p1">byref</param>
+        public void ByRef(ref int p1) { }
+
+
+        /// <summary>example method</summary>
+        /// <param name="p1">out</param>
+        public void Out(out int p1)
+        {
+            p1 = default;
+        }
+
+        /// <summary>
+        /// With
+        /// 
+        /// new
+        /// 
+        /// 
+        /// lines
+        /// </summary>
+        public string NewLines { get; set; }
+
+        /// <summary>indexed</summary>
+        public int this[int index]
+        {
+            get => 0;
+            set => Console.WriteLine(value);
+        }
+    }
+}

--- a/src/NuDoq.Tests/ReaderFixture.cs
+++ b/src/NuDoq.Tests/ReaderFixture.cs
@@ -725,55 +725,5 @@ End", method.ToText());
                 //File.AppendAllLines("C:\\Temp\\" + platform + ".txt", new[] { element.ToString() });
             }
         }
-
-        /// <summary>
-        /// This element contains 
-        /// <custom id="value">
-        /// element with <nested class="help">nested</nested> elements.
-        /// </custom>
-        /// </summary>
-        /// <remarks>
-        /// <code source="foo.cs" region="example" />
-        /// </remarks>
-        public class CustomXml
-        {
-            ///     <summary>
-            ///   Begin
-            ///  End
-            ///     </summary>
-            public void WeirdIndenting() { }
-
-            /// <preliminary />
-            public void Preliminary() { }
-
-            /// <summary>example method</summary>
-            /// <param name="p1">byref</param>
-            public void ByRef(ref int p1) { }
-
-
-            /// <summary>example method</summary>
-            /// <param name="p1">out</param>
-            public void Out(out int p1)
-            {
-                p1 = default;
-            }
-
-            /// <summary>
-            /// With
-            /// 
-            /// new
-            /// 
-            /// 
-            /// lines
-            /// </summary>
-            public string NewLines { get; set; }
-
-            /// <summary>indexed</summary>
-            public int this[int index]
-            {
-                get => 0;
-                set => Console.WriteLine(value);
-            }
-        }
     }
 }

--- a/src/NuDoq/DictionaryExtensions.cs
+++ b/src/NuDoq/DictionaryExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+namespace NuDoq
+{
+    static class DictionaryExtensions
+    {
+        /// <summary>
+        /// If the <paramref name="value"/> is <see langword="null"/>, the 
+        /// entry is removed, otherwise, its value is assigned in the dictionary.
+        /// </summary>
+        public static void SetOrRemove(this IDictionary<string, string> dictionary, string name, string? value)
+        {
+            if (value == null)
+                dictionary.Remove("href");
+            else
+                dictionary["href"] = value;
+        }
+    }
+}

--- a/src/NuDoq/DocReader.cs
+++ b/src/NuDoq/DocReader.cs
@@ -241,23 +241,23 @@ namespace NuDoq
                             "remarks" => new Remarks(ReadContent(elementNode), attributes),
                             "example" => new Example(ReadContent(elementNode), attributes),
                             "para" => new Para(ReadContent(elementNode), attributes),
-                            "param" => new Param(FindAttribute(elementNode, "name"), ReadContent(elementNode), attributes),
-                            "paramref" => new ParamRef(FindAttribute(elementNode, "name"), attributes),
-                            "typeparam" => new TypeParam(FindAttribute(elementNode, "name"), ReadContent(elementNode), attributes),
-                            "typeparamref" => new TypeParamRef(FindAttribute(elementNode, "name"), attributes),
+                            "param" => new Param(ReadContent(elementNode), attributes),
+                            "paramref" => new ParamRef(attributes),
+                            "typeparam" => new TypeParam(ReadContent(elementNode), attributes),
+                            "typeparamref" => new TypeParamRef(attributes),
                             "code" => new Code(TrimCode(elementNode.Value), attributes),
                             "c" => new C(elementNode.Value, attributes),
-                            "see" => new See(FindAttribute(elementNode, "cref"), FindAttribute(elementNode, "langword"), elementNode.Value, ReadContent(elementNode), attributes),
-                            "seealso" => new SeeAlso(FindAttribute(elementNode, "cref"), elementNode.Value, ReadContent(elementNode), attributes),
-                            "list" => new List(FindAttribute(elementNode, "type"), ReadContent(elementNode), attributes),
+                            "see" => new See(elementNode.Value, ReadContent(elementNode), attributes),
+                            "seealso" => new SeeAlso(elementNode.Value, ReadContent(elementNode), attributes),
+                            "list" => new List(ReadContent(elementNode), attributes),
                             "listheader" => new ListHeader(ReadContent(elementNode), attributes),
                             "term" => new Term(ReadContent(elementNode), attributes),
                             "description" => new Description(ReadContent(elementNode), attributes),
                             "item" => new Item(ReadContent(elementNode), attributes),
-                            "exception" => new Exception(FindAttribute(elementNode, "cref"), ReadContent(elementNode), attributes),
+                            "exception" => new Exception(ReadContent(elementNode), attributes),
                             "value" => new Value(ReadContent(elementNode), attributes),
                             "returns" => new Returns(ReadContent(elementNode), attributes),
-                            _ => new UnknownElement(elementNode, ReadContent(elementNode), attributes),
+                            _ => new UnknownElement(elementNode, ReadContent(elementNode)),
                         };
                         break;
                     case XmlNodeType.Text:
@@ -274,12 +274,6 @@ namespace NuDoq
                 }
             }
         }
-
-        /// <summary>
-        /// Retrieves an attribute value if found, otherwise, returns a null string.
-        /// </summary>
-        string FindAttribute(XElement elementNode, string attributeName)
-            => elementNode.Attributes().Where(x => x.Name == attributeName).Select(x => x.Value).FirstOrDefault();
 
         /// <summary>
         /// Trims the text by removing new lines and trimming the indent.

--- a/src/NuDoq/Exception.cs
+++ b/src/NuDoq/Exception.cs
@@ -18,9 +18,10 @@ namespace NuDoq
         /// <param name="attributes">The attributes of the element, if any.</param>
         public Exception(string cref, IEnumerable<Element> elements, IDictionary<string, string> attributes)
             : base(elements, attributes)
-        {
-            Cref = cref;
-        }
+            => Cref = cref;
+
+        internal Exception(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes) { }
 
         /// <summary>
         /// Accepts the specified visitor.
@@ -34,7 +35,11 @@ namespace NuDoq
         /// <summary>
         /// Gets the member id of the exception type.
         /// </summary>
-        public string Cref { get; }
+        public string Cref
+        {
+            get => Attributes.TryGetValue("cref", out var value) ? value : "";
+            set => Attributes.SetOrRemove("cref", value);
+        }
 
         /// <summary>
         /// Returns a <see cref="string" /> that represents this instance.

--- a/src/NuDoq/List.cs
+++ b/src/NuDoq/List.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace NuDoq
@@ -15,22 +16,15 @@ namespace NuDoq
         /// <summary>
         /// Initializes a new instance of the <see cref="List"/> class.
         /// </summary>
-        /// <param name="type">The type of list, which can be "bullet", "number" or "table".</param>
+        /// <param name="type">The type of list.</param>
         /// <param name="elements">The elements.</param>
         /// <param name="attributes">The attributes of the element, if any.</param>
-        public List(string type, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+        public List(ListType type, IEnumerable<Element> elements, IDictionary<string, string> attributes)
             : base(elements, attributes)
-        {
-            Type = ListType.Unknown;
-            if (!string.IsNullOrEmpty(type))
-            {
-                try
-                {
-                    Type = (ListType)System.Enum.Parse(typeof(ListType), System.Globalization.CultureInfo.InvariantCulture.TextInfo.ToTitleCase(type));
-                }
-                catch (ArgumentException) { }
-            }
-        }
+            => Type = type;
+
+        internal List(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes) { }
 
         /// <summary>
         /// Accepts the specified visitor.
@@ -44,7 +38,12 @@ namespace NuDoq
         /// <summary>
         /// Gets the type of list.
         /// </summary>
-        public ListType Type { get; }
+        public ListType Type
+        {
+            get => Attributes.TryGetValue("type", out var value) && System.Enum.TryParse<ListType>(value, true, out var type)
+                  ? type : ListType.Unknown;
+            private set => Attributes["type"] = value.ToString().ToLowerInvariant();
+        }
 
         /// <summary>
         /// Gets the header from the contained elements, if any.

--- a/src/NuDoq/Member.cs
+++ b/src/NuDoq/Member.cs
@@ -25,7 +25,11 @@ namespace NuDoq
         /// <summary>
         /// Gets the member id as specified in the documentation XML.
         /// </summary>
-        public string Id { get; }
+        public string Id
+        {
+            get => Attributes.TryGetValue("name", out var value) ? value : "";
+            set => Attributes["name"] = value;
+        }
 
         /// <summary>
         /// Gets the kind of member.

--- a/src/NuDoq/Param.cs
+++ b/src/NuDoq/Param.cs
@@ -20,6 +20,9 @@ namespace NuDoq
             : base(elements, attributes)
             => Name = name;
 
+        internal Param(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes) { }
+
         /// <summary>
         /// Accepts the specified visitor.
         /// </summary>
@@ -32,7 +35,11 @@ namespace NuDoq
         /// <summary>
         /// Gets the parameter name.
         /// </summary>
-        public string Name { get; }
+        public string Name
+        {
+            get => Attributes.TryGetValue("name", out var value) ? value : "";
+            private set => Attributes["name"] = value;
+        }
 
         /// <summary>
         /// Returns a <see cref="string" /> that represents this instance.

--- a/src/NuDoq/ParamRef.cs
+++ b/src/NuDoq/ParamRef.cs
@@ -19,6 +19,9 @@ namespace NuDoq
             : base(attributes)
             => Name = name;
 
+        internal ParamRef(IDictionary<string, string> attributes)
+            : base(attributes) { }
+
         /// <summary>
         /// Accepts the specified visitor.
         /// </summary>
@@ -31,7 +34,11 @@ namespace NuDoq
         /// <summary>
         /// Gets the name of the referenced parameter.
         /// </summary>
-        public string Name { get; }
+        public string Name
+        {
+            get => Attributes.TryGetValue("name", out var value) ? value : "";
+            private set => Attributes["name"] = value;
+        }
 
         /// <summary>
         /// Returns a <see cref="string" /> that represents this instance.

--- a/src/NuDoq/See.cs
+++ b/src/NuDoq/See.cs
@@ -26,6 +26,10 @@ namespace NuDoq
             Content = content;
         }
 
+        internal See(string content, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
+            => Content = content;
+
         /// <summary>
         /// Accepts the specified visitor.
         /// </summary>
@@ -36,24 +40,36 @@ namespace NuDoq
         }
 
         /// <summary>
-        /// Gets the member id of the referenced member.
-        /// </summary>
-        public string Cref { get; }
-
-        /// <summary>
-        /// Gets the original langword attribute.
-        /// </summary>
-        public string Langword { get; }
-
-        /// <summary>
         /// Gets the reference's text.
         /// </summary>
         public string Content { get; }
 
         /// <summary>
+        /// Gets the member id of the referenced member.
+        /// </summary>
+        public string Cref
+        {
+            get => Attributes.TryGetValue("cref", out var value) ? value : "";
+            set => Attributes.SetOrRemove("cref", value);
+        }
+
+        /// <summary>
+        /// Gets the original langword attribute.
+        /// </summary>
+        public string Langword
+        {
+            get => Attributes.TryGetValue("langword", out var value) ? value : "";
+            set => Attributes.SetOrRemove("langword", value);
+        }
+
+        /// <summary>
         /// Gets the hyperlink, if present.
         /// </summary>
-        public string? Href => Attributes.TryGetValue("href", out var href) ? href : null;
+        public string? Href
+        {
+            get => Attributes.TryGetValue("href", out var value) ? value : "";
+            set => Attributes.SetOrRemove("href", value);
+        }
 
         /// <summary>
         /// Returns a <see cref="string" /> that represents this instance.

--- a/src/NuDoq/SeeAlso.cs
+++ b/src/NuDoq/SeeAlso.cs
@@ -24,6 +24,10 @@ namespace NuDoq
             Content = content;
         }
 
+        internal SeeAlso(string content, IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes)
+            => Content = content;
+
         /// <summary>
         /// Accepts the specified visitor.
         /// </summary>
@@ -34,19 +38,27 @@ namespace NuDoq
         }
 
         /// <summary>
-        /// Gets the member id of the referenced member.
-        /// </summary>
-        public string Cref { get; }
-
-        /// <summary>
         /// Gets the reference's text.
         /// </summary>
         public string Content { get; }
 
         /// <summary>
+        /// Gets the member id of the referenced member.
+        /// </summary>
+        public string Cref
+        {
+            get => Attributes.TryGetValue("cref", out var value) ? value : "";
+            set => Attributes.SetOrRemove("cref", value);
+        }
+
+        /// <summary>
         /// Gets the hyperlink, if present.
         /// </summary>
-        public string? Href => Attributes.TryGetValue("href", out var href) ? href : null;
+        public string? Href
+        {
+            get => Attributes.TryGetValue("href", out var value) ? value : "";
+            set => Attributes.SetOrRemove("href", value);
+        }
 
         /// <summary>
         /// Returns a <see cref="string" /> that represents this instance.

--- a/src/NuDoq/TypeParam.cs
+++ b/src/NuDoq/TypeParam.cs
@@ -20,6 +20,9 @@ namespace NuDoq
             : base(elements, attributes)
             => Name = name;
 
+        internal TypeParam(IEnumerable<Element> elements, IDictionary<string, string> attributes)
+            : base(elements, attributes) { }
+
         /// <summary>
         /// Accepts the specified visitor.
         /// </summary>
@@ -32,7 +35,11 @@ namespace NuDoq
         /// <summary>
         /// Gets the name of the type parameter.
         /// </summary>
-        public string Name { get; }
+        public string Name
+        {
+            get => Attributes.TryGetValue("name", out var value) ? value : "";
+            private set => Attributes["name"] = value;
+        }
 
         /// <summary>
         /// Returns a <see cref="string" /> that represents this instance.

--- a/src/NuDoq/TypeParamRef.cs
+++ b/src/NuDoq/TypeParamRef.cs
@@ -19,6 +19,9 @@ namespace NuDoq
             : base(attributes)
             => Name = name;
 
+        internal TypeParamRef(IDictionary<string, string> attributes)
+            : base(attributes) { }
+
         /// <summary>
         /// Accepts the specified visitor.
         /// </summary>
@@ -31,7 +34,11 @@ namespace NuDoq
         /// <summary>
         /// Gets the name of the referenced type parameter.
         /// </summary>
-        public string Name { get; }
+        public string Name
+        {
+            get => Attributes.TryGetValue("name", out var value) ? value : "";
+            private set => Attributes["name"] = value;
+        }
 
         /// <summary>
         /// Returns a <see cref="string" /> that represents this instance.

--- a/src/NuDoq/UnknownElement.cs
+++ b/src/NuDoq/UnknownElement.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Xml.Linq;
 
 namespace NuDoq
@@ -13,9 +14,8 @@ namespace NuDoq
         /// </summary>
         /// <param name="xml">The <see cref="XElement"/> containing the entire element markup.</param>
         /// <param name="content">The child content.</param>
-        /// <param name="attributes">The attributes of the element, if any.</param>
-        public UnknownElement(XElement xml, IEnumerable<Element> content, IDictionary<string, string> attributes)
-            : base(content, attributes)
+        public UnknownElement(XElement xml, IEnumerable<Element> content)
+            : base(content, new ReadOnlyDictionary<string, string>(new Dictionary<string, string>()))
             => Xml = xml;
 
         /// <summary>


### PR DESCRIPTION
When visiting to generate/update an XML doc, we were losing the custom attributes that could have been applied to elements.

By making all typed properties a direct pass-through to the dictionary of custom attributes, we simplify significantly the XmlVisitor, while at the same time ensuring both are always in sync. This means reading and then modifying the in-memory model and writing back, should result in a fairly faithful rendering of the original + changes. (no exact round-tripping including formatting is ensured though, for now, seems unnecessary).

Fully custom elements also are preserved as-is, uncluding its original attributes, and the API of the UnknownElement will now throw if you try to modify its Attributes dictionary, since it's just exposing the underlying XElement, which should be modified itself instead.

Fixes #37.