### PR TITLE
Reading the text within CDATA nodes

### DIFF
--- a/src/NuDoq.Tests/CustomXml.cs
+++ b/src/NuDoq.Tests/CustomXml.cs
@@ -29,7 +29,7 @@ namespace NuDoq
         /// <summary>
         /// <![CDATA[<><> character data]]>
         /// </summary>
-        public void HasCData() {}
+        public void HasCData() { }
 
         /// <summary>example method</summary>
         /// <param name="p1">byref</param>

--- a/src/NuDoq.Tests/CustomXml.cs
+++ b/src/NuDoq.Tests/CustomXml.cs
@@ -26,6 +26,11 @@ namespace NuDoq
         /// <preliminary />
         public void Preliminary() { }
 
+        /// <summary>
+        /// <![CDATA[<><> character data]]>
+        /// </summary>
+        public void HasCData() {}
+
         /// <summary>example method</summary>
         /// <param name="p1">byref</param>
         public void ByRef(ref int p1) { }

--- a/src/NuDoq.Tests/ReaderFixture.cs
+++ b/src/NuDoq.Tests/ReaderFixture.cs
@@ -688,6 +688,16 @@ lines", method.Elements.OfType<Summary>().First().Elements.OfType<Text>().First(
 End", method.ToText());
         }
 
+        [Fact]
+        public void when_reading_cdata_then_preserves_text()
+        {
+            var member = DocReader.Read(Assembly.GetExecutingAssembly());
+            var method = member.Elements.OfType<Method>()
+                .FirstOrDefault(m => m.Info?.DeclaringType == typeof(CustomXml) && m.Info?.Name == nameof(CustomXml.HasCData));
+
+            Assert.NotNull(method);
+            Assert.Equal("<><> character data", method.ToText());
+        }
 
         class CountingVisitor : Visitor
         {

--- a/src/NuDoq/DocReader.cs
+++ b/src/NuDoq/DocReader.cs
@@ -263,6 +263,9 @@ namespace NuDoq
                     case XmlNodeType.Text:
                         element = new Text(TrimText(((XText)node).Value));
                         break;
+                    case XmlNodeType.CDATA:
+                        element = new Text(((XCData)node).Value);
+                        break;
                     default:
                         break;
                 }


### PR DESCRIPTION
Fixes #57 

Treats the contents of `<![CDATA[[]]>` nodes as text.  This is useful for providing code usage examples in `<example>` nodes.